### PR TITLE
Add local lazo dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,9 +4,7 @@ var jshint = require('gulp-jshint');
 var nodemon = require('gulp-nodemon');
 var path = require('path');
 var sass = require('gulp-sass');
-// assumes first path is the global node modules path
-var NODE_PATH = process.env.NODE_PATH.split(':')[0];
-var lazo = path.normalize(NODE_PATH + path.sep + 'lazo' + path.sep + 'lazo.js');
+var lazo = path.normalize('.' + path.sep + 'node_modules' + path.sep + 'lazo' + path.sep + 'lazo.js');
 
 gulp.task('lint', function () {
     return gulp.src(['src/**/*.js', '!src/app/client/bower_components/**/**.*', '!.bowerrc'])

--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "lazo.org",
-  "version": "0.0.1",
-  "description": "I am lazojs.org.",
-  "homepage": "https://github.com/walmartlabs/lazojs.org",
-  "keywords": [
-    "lazo",
-    "lazojs",
-    "documentation"
-  ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "/blob/master/LICENSE-MIT"
+    "name": "lazo.org",
+    "version": "0.0.1",
+    "description": "I am lazojs.org.",
+    "homepage": "https://github.com/walmartlabs/lazojs.org",
+    "keywords": [
+        "lazo",
+        "lazojs",
+        "documentation"
+    ],
+    "licenses": [
+        {
+            "type": "MIT",
+            "url": "/blob/master/LICENSE-MIT"
+        }
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/walmartlabs/lazojs.org"
+    },
+    "bugs": {
+        "url": "https://github.com/walmartlabs/lazojs.org/issues"
+    },
+    "private": true,
+    "main": "src/index",
+    "scripts": {
+        "test": "gulp ci"
+    },
+    "devDependencies": {
+        "gulp": "3.8.8",
+        "gulp-jshint": "1.8.4",
+        "gulp-nodemon": "1.0.4",
+        "node-bourbon": "1.2.3",
+        "gulp-sass": "1.2.0"
+    },
+    "dependencies": {
+        "lazo": "^1.1.1"
     }
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/walmartlabs/lazojs.org"
-  },
-  "bugs": {
-    "url": "https://github.com/walmartlabs/lazojs.org/issues"
-  },
-  "private": true,
-  "main": "src/index",
-  "scripts": {
-    "test": "gulp ci"
-  },
-  "devDependencies": {
-    "gulp": "3.8.8",
-    "gulp-jshint": "1.8.4",
-    "gulp-nodemon": "1.0.4",
-    "node-bourbon": "1.2.3",
-    "gulp-sass": "1.2.0"
-  },
-  "dependencies": {
-    "lazo": "^1.1.1"
-  }
 }

--- a/package.json
+++ b/package.json
@@ -1,36 +1,39 @@
 {
-    "name": "lazo.org",
-    "version": "0.0.1",
-    "description": "I am lazojs.org.",
-    "homepage": "https://github.com/walmartlabs/lazojs.org",
-    "keywords": [
-        "lazo",
-        "lazojs",
-        "documentation"
-    ],
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "/blob/master/LICENSE-MIT"
-        }
-    ],
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/walmartlabs/lazojs.org"
-    },
-    "bugs": {
-        "url": "https://github.com/walmartlabs/lazojs.org/issues"
-    },
-    "private": true,
-    "main": "src/index",
-    "scripts": {
-        "test": "gulp ci"
-    },
-    "devDependencies": {
-        "gulp": "3.8.8",
-        "gulp-jshint": "1.8.4",
-        "gulp-nodemon": "1.0.4",
-        "node-bourbon": "1.2.3",
-        "gulp-sass": "1.2.0"
+  "name": "lazo.org",
+  "version": "0.0.1",
+  "description": "I am lazojs.org.",
+  "homepage": "https://github.com/walmartlabs/lazojs.org",
+  "keywords": [
+    "lazo",
+    "lazojs",
+    "documentation"
+  ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "/blob/master/LICENSE-MIT"
     }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/walmartlabs/lazojs.org"
+  },
+  "bugs": {
+    "url": "https://github.com/walmartlabs/lazojs.org/issues"
+  },
+  "private": true,
+  "main": "src/index",
+  "scripts": {
+    "test": "gulp ci"
+  },
+  "devDependencies": {
+    "gulp": "3.8.8",
+    "gulp-jshint": "1.8.4",
+    "gulp-nodemon": "1.0.4",
+    "node-bourbon": "1.2.3",
+    "gulp-sass": "1.2.0"
+  },
+  "dependencies": {
+    "lazo": "^1.1.1"
+  }
 }


### PR DESCRIPTION
This is just a preference so no problem if it's not wanted, but this way we can version lazo with the app rather than relying on the host system to provide it. (I ran into this because I didn't have lazo globally).